### PR TITLE
add the ability to support using unicast and authentication

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,10 @@ keepalived_router_info: []
 #   vip_addresses:
 #     - 192.168.202.100
 #     - 192.168.202.101
+#   use_unicast: true
+#   # set unicasts settings in hostvars
+#   nopreempt: true
+#   auth_pass: password1234
 # - name: vrrp_2
 #   check_script:
 #     - name: chk_nginx

--- a/templates/etc/keepalived/keepalived.conf.j2
+++ b/templates/etc/keepalived/keepalived.conf.j2
@@ -9,8 +9,10 @@ vrrp_script {{ chk.name }} {
 }
 {%       endfor %}
 {%     endif %}
+
 vrrp_instance {{ item.name }} {
   interface {{ item.vip_int }}
+  
 {%     if inventory_hostname == item.master_node %}
   state MASTER
   priority {{ item.router_pri_master }}
@@ -18,12 +20,14 @@ vrrp_instance {{ item.name }} {
   state BACKUP
   priority {{ item.router_pri_backup }}
 {%     endif %}
+
   virtual_router_id {{ item.router_id }}
   virtual_ipaddress {
 {%     for ip in item.vip_addresses %}
     {{ ip }}
 {%     endfor %}
   }
+  
 {%     if item.check_script is defined %}
 {%       for chk in item.check_script %}
   track_script {
@@ -31,6 +35,27 @@ vrrp_instance {{ item.name }} {
   }
 {%       endfor %}
 {%     endif %}
+
+{%- if item.nopreempt %}
+  nopreempt
+{% endif -%}
+
+{% if item.use_unicast %}
+  unicast_src_ip {{ unicast_src_ip }}
+{% for peer in unicast_peers %}
+  unicast_peer {
+    {{ peer }}
+{% endfor -%}
+  }
+{% endif %}
+
+{% if item.auth_pass is defined %}
+  authentication {
+    auth_type PASS
+    auth_pass {{ item.auth_pass }}
+  }
+{% endif %}
+
 }
 {%   endfor %}
 {% endif %}


### PR DESCRIPTION
A sample group_var would be something like this:

```yaml
---
keepalived_config: true
keepalived_router_info:
  - name: vrrp_52
    check_script:
      - name: chk_haproxy
        script: 'killall -0 haproxy'
        interval: 2
        weight: 2
    master_node: "{{ groups['keepalive'][0] }}"
    router_id: 52
    router_pri_backup: 99
    router_pri_master: 100
    vip_int: '{{ ansible_eth0.device }}'
    vip_addresses:
      - 192.168.10.250
    use_unicast: true
    # see hostvars for unicast settings
    nopreempt: true
    auth_pass: password1234
```
With host_vars for unicast settings being like this:

host1
```yaml
---
unicast_src_ip: "{{ hostvars[groups['keepalive'][0]]['ansible_eth0']['ipv4']['address'] }}"
unicast_peers:
  - "{{ hostvars[groups['keepalive'][1]]['ansible_eth0']['ipv4']['address'] }}"
```

host2
```yaml
---
unicast_src_ip: "{{ hostvars[groups['keepalive'][1]]['ansible_eth0']['ipv4']['address'] }}"
unicast_peers:
  - "{{ hostvars[groups['keepalive'][0]]['ansible_eth0']['ipv4']['address'] }}"
```